### PR TITLE
[Housekeeping] Add link to example Loom video in PR template scaffold

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,14 +1,8 @@
-<!-- NOTE: Please delete items that aren't relevant for this pull request -->
-
 ## Context
 
 As `<who>` `<when>` `<where>`, I want `<what>` because `<why>`
 
-<!--
-- Examples: 
-- As a platform engineering repository I want to include a PR template to make review streamlined and provide accountability
-- As a cloud solution architect I want to add a CI/CD template so that others can more easily stand up CI/CD 
--->
+Example: `As a cloud solution architect I want to add a .devcontainer to demonstrate spinning up a python dev environment so that repo visitors can leverage this to start developing more quickly` 
 
 ## What does this PR do?
 
@@ -16,10 +10,10 @@ As `<who>` `<when>` `<where>`, I want `<what>` because `<why>`
 
 ## How can someone see this change?
 
-<!--
-- What is changed? How can someone run the code or test? How can it be observed?
-- LOOM VIDEOS ARE GREAT! 
--->
+Example:
+- Loom videos are a great way to explain what this PR is for and any nuances around the files
+- [Example Loom](https://www.loom.com/share/c5255ca8ab94481e89b2f1f36bb7731f?sid=367733cf-bd3e-402c-ae30-67c3558885b3) 
+- How can someone run this, test this, see what it does, are there comments they should look at?
 
 ## Quality assurance steps
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,8 +1,14 @@
+<!-- NOTE: Please delete items that aren't relevant for this pull request -->
+
 ## Context
 
 As `<who>` `<when>` `<where>`, I want `<what>` because `<why>`
 
-Example: `As a cloud solution architect I want to add a .devcontainer to demonstrate spinning up a python dev environment so that repo visitors can leverage this to start developing more quickly` 
+<!--
+- Examples: 
+- As a platform engineering repository I want to include a PR template to make review streamlined and provide accountability
+- As a cloud solution architect I want to add a CI/CD template so that others can more easily stand up CI/CD 
+-->
 
 ## What does this PR do?
 
@@ -10,10 +16,11 @@ Example: `As a cloud solution architect I want to add a .devcontainer to demonst
 
 ## How can someone see this change?
 
-Example:
+<!--
+- What is changed? How can someone run the code or test? How can it be observed?
 - Loom videos are a great way to explain what this PR is for and any nuances around the files
 - [Example Loom](https://www.loom.com/share/c5255ca8ab94481e89b2f1f36bb7731f?sid=367733cf-bd3e-402c-ae30-67c3558885b3) 
-- How can someone run this, test this, see what it does, are there comments they should look at?
+-->
 
 ## Quality assurance steps
 


### PR DESCRIPTION
## Context

As Platform Engineering Maintainer I want to add a PR template to encourage PR explainability and make it easier for reviewers to understand PR purpose.

## What does this PR do?

- [x] Adds a PR template to be built on with link to Loom video

## How can someone see this change?

- [Loom video link](https://www.loom.com/share/c5255ca8ab94481e89b2f1f36bb7731f?sid=c07d373f-269b-4ce1-9e83-74335cf457d5)
- Link is hardcoded in raw `.md` file

## Quality assurance steps

- [x] I have performed a self-review of the code before asking others to review, providing comments to help clarify ambiguity or reduce complexity
