### PR TITLE
Feature/dagger pr fixes

### DIFF
--- a/.github/workflows/dagger_terraform.yml
+++ b/.github/workflows/dagger_terraform.yml
@@ -1,4 +1,4 @@
-name: dagger  # Name of the workflow
+name: dagger_terraform  # Name of the workflow
 
 on: 
   workflow_dispatch

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Explore our comprehensive index of platform engineering topics and modules to de
 
 - **[Platform Engineering Resources](index.md)**
 
+- **[Dagger Resources](docs/dagger/README.md)**
+
 <!-- Contributing section -->
 ## 🤝 Contributing
 

--- a/docs/dagger/README.md
+++ b/docs/dagger/README.md
@@ -283,10 +283,10 @@ The output of the plan is looking good and has all the changes I would expect ba
 
 Now that we have successfully executed our Dagger pipeline locally, it's time to automate it in a CI/CD environment. This will ensure that our Terraform deployments are consistently executed whenever code is pushed to our repository.
 
-We will use GitHub Actions to automate the execution of our Dagger pipeline. Below is a sample workflow file that runs Terraform inside our Dagger container whenever changes are pushed to the repository (the location of this file is .github\workflows\dagger.yml).
+We will use GitHub Actions to automate the execution of our Dagger pipeline. Below is a sample workflow file that runs Terraform inside our Dagger container whenever changes are pushed to the repository (the location of this file is .github\workflows\dagger_terraform.yml).
 
 ```yaml
-name: dagger  # Name of the workflow
+name: dagger_terraform  # Name of the workflow
 
 on:
   push:

--- a/docs/dagger/README.md
+++ b/docs/dagger/README.md
@@ -249,7 +249,8 @@ class PlatformEngineering:
 
 3️⃣ **Executing Terraform Inside a Container** 🚀
 
-- The pipeline runs Terraform **inside a containerized environment** using the official `hashicorp/terraform:1.11` Docker image.  
+- The pipeline runs Terraform **inside a containerized environment** using the official `hashicorp/terraform:1.11` Docker image.
+- Dagger exposes a type called `Container` that represents the state of an OCI-compatible (ie: Docker) container. This is passed to the Dagger Engine and is passed to a Dagger Function's code as if it were just another variable.
 - It performs the following steps:  
 
   - Initializes Terraform with `terraform init`


### PR DESCRIPTION
Addressing feedback provided by @david-hurley and @kevinevans1 in my previous PR: https://github.com/codetocloudinc/platform-engineering/pull/36.

Namely, 

- Renaming the dagger/terraform ci/cd pipeline to allow for additional pipelines to be added to the workflows directory that are associated with Dagger
- Add blurb in Dagger docs on the container type
- Added link to Dagger README in the repos root README to assist people in finding the Dagger content